### PR TITLE
Added support for deleting indexes.

### DIFF
--- a/splunk/com/splunk/IndexCollection.java
+++ b/splunk/com/splunk/IndexCollection.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012 Splunk, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"): you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.splunk;
+
+public class IndexCollection extends EntityCollection<Index> {
+    /**
+     * Class constructor.
+     *
+     * @param service The connected {@code Service} instance.
+     */
+    IndexCollection(Service service) {
+        super(service, "data/indexes", Index.class);
+    }
+
+    /**
+     * Class constructor.
+     *
+     * @param service The connected {@code Service} instance.
+     * @param args Arguments to use when you instantiate the entity, such as
+     * "count" and "offset".
+     */
+    IndexCollection(Service service, Args args) {
+        super(service, "data/indexes", Index.class, args);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public Index remove(String key) {
+        if (this.service.versionCompare("5.0") < 0) {
+            throw new SplunkException(
+                    SplunkException.UNSUPPORTED,
+                    "Indexes cannot be deleted via the REST API in versions prior to 5.0"
+            );
+        } else {
+            return (Index)super.remove(key);
+        }
+    }
+}

--- a/splunk/com/splunk/Service.java
+++ b/splunk/com/splunk/Service.java
@@ -454,8 +454,8 @@ public class Service extends HttpService {
      *
      * @return A collection of indexes.
      */
-    public EntityCollection<Index> getIndexes() {
-        return new EntityCollection<Index>(this, "data/indexes", Index.class);
+    public IndexCollection getIndexes() {
+        return new IndexCollection(this);
     }
 
     /**

--- a/splunk/com/splunk/SplunkException.java
+++ b/splunk/com/splunk/SplunkException.java
@@ -23,6 +23,7 @@ public class SplunkException extends RuntimeException {
     public static int JOB_NOTREADY = 1;
     public static int TIMEOUT = 2;
     public static int AMBIGUOUS = 3;
+    public static int UNSUPPORTED = 4;
 
     SplunkException(int code, String text) {
         this.code = code;

--- a/tests/com/splunk/IndexTest.java
+++ b/tests/com/splunk/IndexTest.java
@@ -22,8 +22,34 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.junit.Test;
+import java.lang.Thread;
 
 public class IndexTest extends SplunkTestCase {
+    @Test
+    public void testDeleteIndex() throws Exception {
+        Service service = connect();
+
+        if (service.versionCompare("5.0") < 0) {
+
+        }
+
+        String indexName = temporaryName();
+        EntityCollection<Index> indexes = service.getIndexes();
+        Index index = indexes.create(indexName);
+        SplunkTestCase.assertTrue(indexes.containsKey(indexName));
+        indexes.remove(indexName);
+
+        int nTries = 10;
+        while (nTries > 0) {
+            if (indexes.containsKey(indexName)) {
+                Thread.sleep(300);
+            } else {
+                return;
+            }
+        }
+        SplunkTestCase.fail("Index not deleted within allotted time.");
+    }
+
     final static String assertRoot = "Index assert: ";
 
     private void wait_event_count(Index index, int value, int seconds) {

--- a/tests/com/splunk/SplunkTestCase.java
+++ b/tests/com/splunk/SplunkTestCase.java
@@ -20,11 +20,20 @@ import com.splunk.sdk.Command;
 import java.net.Socket;
 import junit.framework.TestCase;
 import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
 
 // Shared base class for Splunk SDK unit tests, contains common unit setup
 // and a collection of helper functions.
 public class SplunkTestCase extends TestCase {
     final static String assertRoot = "Test Support assert: ";
+
+    protected String temporaryName() {
+        UUID u = UUID.randomUUID();
+        String name = "delete-me-" + u.toString();
+        return name;
+    }
 
     Command command;
 


### PR DESCRIPTION
Strictly speaking, it was already there. Subclasses EntityCollection to throw an exception when trying to remove an index on 4.x or earlier.
Put in the first bits of the new test infrastructure that I needed to test it.
