### PR TITLE
Narrow ResultsReader methods to throw IOException instead of Exception.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@
 
 * StormService has been removed. It will be restored in a subsequent release.
 
+* ResultsReader methods now throws IOException instead of a plain Exception.
+    - Callers no longer need to handle a plain Exception.
+
 
 ## Version 0.8.0 (beta)
 

--- a/examples/com/splunk/examples/search/Program.java
+++ b/examples/com/splunk/examples/search/Program.java
@@ -17,9 +17,8 @@
 package com.splunk.examples.search;
 
 import com.splunk.*;
-import com.splunk.ResultsReaderCsv;
-import com.splunk.ResultsReaderJson;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
@@ -209,8 +208,8 @@ public class Program {
                         System.out.println("  " + key + " --> " + map.get(key));
                 }
                 resultsReader.close();
-            } catch (Exception e) {
-                System.out.println("exception: " + e);
+            } catch (IOException e) {
+                System.out.println("I/O exception: " + e);
             }
         }
         else {

--- a/examples/com/splunk/examples/search_blocking/Program.java
+++ b/examples/com/splunk/examples/search_blocking/Program.java
@@ -174,8 +174,8 @@ public class Program {
                     System.out.println("   " + map);
                 }
                 resultsReader.close();
-            } catch (Exception e) {
-                System.out.println("Xml exception: " + e);
+            } catch (IOException e) {
+                System.out.println("I/O exception: " + e);
             }
         }
         else {

--- a/examples/com/splunk/examples/search_oneshot/Program.java
+++ b/examples/com/splunk/examples/search_oneshot/Program.java
@@ -128,8 +128,8 @@ public class Program {
                     System.out.println("   " + map);
                 }
                 resultsReader.close();
-            } catch (Exception e) {
-                System.out.println("Xml exception: " + e);
+            } catch (IOException e) {
+                System.out.println("I/O exception: " + e);
             }
         }
         else {

--- a/examples/com/splunk/examples/search_realtime/Program.java
+++ b/examples/com/splunk/examples/search_realtime/Program.java
@@ -175,8 +175,8 @@ public class Program {
                     System.out.println("   " + map);
                 }
                 resultsReader.close();
-            } catch (Exception e) {
-                System.out.println("Xml exception: " + e);
+            } catch (IOException e) {
+                System.out.println("I/O exception: " + e);
             }
         }
         else {

--- a/splunk/com/splunk/ResultsReader.java
+++ b/splunk/com/splunk/ResultsReader.java
@@ -34,12 +34,8 @@ public abstract class ResultsReader {
      * export.
      * @throws IOException If an IO exception occurs.
      */
-    public ResultsReader(InputStream inputStream) throws Exception {
-        try {
-            inputStreamReader = new
-                InputStreamReader(inputStream, "UTF-8");
-        }
-        catch (UnsupportedEncodingException e) { assert false; }
+    public ResultsReader(InputStream inputStream) throws IOException {
+        inputStreamReader = new InputStreamReader(inputStream, "UTF-8");
     }
 
     /**
@@ -47,7 +43,7 @@ public abstract class ResultsReader {
      *
      * @throws Exception on Exception
      */
-    public void close() throws Exception {
+    public void close() throws IOException {
         if (inputStreamReader != null)
             inputStreamReader.close();
         inputStreamReader = null;
@@ -59,7 +55,5 @@ public abstract class ResultsReader {
      * @return The hash map of key-value pairs for an entire event.
      * @throws Exception on Exception.
      */
-    public HashMap<String, String> getNextEvent() throws Exception {
-        return null;
-    }
+    public abstract HashMap<String, String> getNextEvent() throws IOException;
 }

--- a/splunk/com/splunk/ResultsReaderCsv.java
+++ b/splunk/com/splunk/ResultsReaderCsv.java
@@ -18,6 +18,8 @@ package com.splunk;
 
 import au.com.bytecode.opencsv.CSVReader;
 import com.splunk.ResultsReader;
+
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -37,7 +39,7 @@ public class ResultsReaderCsv extends ResultsReader {
      * @param inputStream The stream to be parsed.
      * @throws Exception On exception.
      */
-    public ResultsReaderCsv(InputStream inputStream) throws Exception {
+    public ResultsReaderCsv(InputStream inputStream) throws IOException {
         super(inputStream);
         csvReader = new CSVReader(new InputStreamReader(inputStream));
         // initial line contains the keys, except for oneshot -- which contains
@@ -49,7 +51,7 @@ public class ResultsReaderCsv extends ResultsReader {
     }
 
     /** {@inheritDoc} */
-    @Override public void close() throws Exception {
+    @Override public void close() throws IOException {
         super.close();
         if (csvReader != null)
             csvReader.close();
@@ -57,7 +59,7 @@ public class ResultsReaderCsv extends ResultsReader {
     }
 
     /** {@inheritDoc} */
-    @Override public HashMap<String, String> getNextEvent() throws Exception {
+    @Override public HashMap<String, String> getNextEvent() throws IOException {
         HashMap<String, String> returnData = null;
         String[] line;
 

--- a/splunk/com/splunk/ResultsReaderJson.java
+++ b/splunk/com/splunk/ResultsReaderJson.java
@@ -39,7 +39,7 @@ public class ResultsReaderJson extends ResultsReader {
      * @param inputStream The stream to be parsed.
      * @throws Exception On exception.
      */
-    public ResultsReaderJson(InputStream inputStream) throws Exception {
+    public ResultsReaderJson(InputStream inputStream) throws IOException {
         super(inputStream);
         jsonReader = new JsonReader(new InputStreamReader(inputStream));
         // if stream is empty, return a null reader.
@@ -103,7 +103,7 @@ public class ResultsReaderJson extends ResultsReader {
     }
 
     /** {@inheritDoc} */
-    @Override public void close() throws Exception {
+    @Override public void close() throws IOException {
         super.close();
         if (jsonReader != null)
             jsonReader.close();
@@ -111,7 +111,7 @@ public class ResultsReaderJson extends ResultsReader {
     }
 
     /** {@inheritDoc} */
-    @Override public HashMap<String, String> getNextEvent() throws Exception {
+    @Override public HashMap<String, String> getNextEvent() throws IOException {
         HashMap<String, String> returnData = null;
         String name = "";
 

--- a/tests/com/splunk/IndexTest.java
+++ b/tests/com/splunk/IndexTest.java
@@ -509,9 +509,7 @@ public class IndexTest extends SDKTestCase {
                 numEvents++;
             }
             return numEvents;
-        } catch (Exception e) {
-            // TODO: Stop catching Exception once ResultsReader's interface
-            //       has been cleaned up to not throw raw Exceptions.
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/tests/com/splunk/ResultsReaderTest.java
+++ b/tests/com/splunk/ResultsReaderTest.java
@@ -19,6 +19,7 @@ package com.splunk;
 import junit.framework.TestCase;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +45,7 @@ public class ResultsReaderTest extends TestCase {
     }
 
     @Test
-    public void testResults() throws Exception {
+    public void testResults() throws IOException {
         InputStream input = openResource("results.xml");
         assertNotNull("Could not open results.xml", input);
         ResultsReaderXml reader = new ResultsReaderXml(input);
@@ -84,7 +85,7 @@ public class ResultsReaderTest extends TestCase {
     }
 
     @Test
-    public void testReadRawField() throws Exception {
+    public void testReadRawField() throws IOException {
         InputStream input = openResource("raw_field.xml");
         assertNotNull("Could not open raw_field.xml", input);
         ResultsReaderXml reader = new ResultsReaderXml(input);

--- a/tests/com/splunk/SearchJobTest.java
+++ b/tests/com/splunk/SearchJobTest.java
@@ -396,7 +396,7 @@ public class SearchJobTest extends SDKTestCase {
             }
 
             return count;
-        } catch (Exception e) {
+        } catch (IOException e) {
             fail(e.toString());
             return -1;
         }


### PR DESCRIPTION
See DVPL-1236.
