### PR TITLE
Prohibit uses of wildcarded namespaces in Collection.{get,remove,contains}.

### DIFF
--- a/splunk/com/splunk/EntityCollection.java
+++ b/splunk/com/splunk/EntityCollection.java
@@ -132,7 +132,9 @@ public class EntityCollection<T extends Entity> extends ResourceCollection<T> {
      * @return This collection.
      */
     public T remove(String key, Args namespace) {
+        Util.ensureNamespaceIsExact(namespace);
         validate();
+        
         if (!containsKey(key)) return null;
         LinkedList<T> entities = items.get(key);
         String pathMatcher = service.fullpath("", namespace);

--- a/splunk/com/splunk/InputCollection.java
+++ b/splunk/com/splunk/InputCollection.java
@@ -177,6 +177,7 @@ public class InputCollection extends EntityCollection<Input> {
      * exist.
      */
    public Input get(Object key, Args namespace) {
+       Util.ensureNamespaceIsExact(namespace);
        return retrieveInput((String)key, namespace);
    }
 
@@ -335,6 +336,8 @@ public class InputCollection extends EntityCollection<Input> {
      */
     @Override public Input remove(
             String key, Args namespace) {
+        Util.ensureNamespaceIsExact(namespace);
+        
         Input input = retrieveInput(key, namespace);
         if (input != null) {
             input.remove();
@@ -368,6 +371,7 @@ public class InputCollection extends EntityCollection<Input> {
     }
 
     private Input retrieveInput(String key, Args namespace) {
+        Util.ensureNamespaceIsExact(namespace);
         validate();
         
         // Because scripted input names are not 1:1 with the original name

--- a/splunk/com/splunk/ResourceCollection.java
+++ b/splunk/com/splunk/ResourceCollection.java
@@ -79,7 +79,9 @@ public class ResourceCollection<T extends Resource>
      * @return {@code true} if the key exists, {@code false} if not.
      */
     public boolean containsKey(Object key, Args namespace) {
+        Util.ensureNamespaceIsExact(namespace);
         validate();
+        
         LinkedList<T> entities = items.get(key);
         if (entities == null || entities.size() == 0) return false;
         String pathMatcher = service.fullpath("", namespace);
@@ -192,7 +194,9 @@ public class ResourceCollection<T extends Resource>
      * exist.
      */
     public T get(Object key, Args namespace) {
+        Util.ensureNamespaceIsExact(namespace);
         validate();
+        
         LinkedList<T> entities = items.get(key);
         if (entities == null || entities.size() == 0) return null;
         String pathMatcher = service.fullpath("", namespace);

--- a/splunk/com/splunk/Service.java
+++ b/splunk/com/splunk/Service.java
@@ -984,8 +984,7 @@ public class Service extends BaseService {
      * optional arguments for this endpoint.
      * @return A collection of in-progress oneshot uploads
      */
-    public EntityCollection<Upload>
-    getUploads(Args namespace) {
+    public EntityCollection<Upload> getUploads(Args namespace) {
         return new EntityCollection<Upload>(
             this, "data/inputs/oneshot", Upload.class, namespace);
     }

--- a/splunk/com/splunk/Util.java
+++ b/splunk/com/splunk/Util.java
@@ -117,4 +117,22 @@ class Util {
             return file;
         }
     }
+    
+    /**
+     * Throws an IllegalArgumentException if the specified namespace
+     * is a wildcarded namespace.
+     */
+    public static void ensureNamespaceIsExact(Args namespace) {
+        String app = (String)namespace.get("app");
+        String owner = (String)namespace.get("owner");
+        
+        boolean wildcardedApp = (app == null || app.equals("-"));
+        boolean wildcardedOwner = (owner == null || owner.equals("-"));
+        boolean isExact = !wildcardedApp && !wildcardedOwner;
+        
+        if (!isExact) {
+            throw new IllegalArgumentException(
+                    "An exact namespace must be provided.");
+        }
+    }
 }


### PR DESCRIPTION
The implementation here requires that most methods that take a `namespace` argument have an exact namespace passed. It is not considered sufficient if the passed namespace is incomplete but becomes exact when combined with the Service namespace.
