### PR TITLE
Removed setTargetRepositoryLocation and setTmpFolder 

### DIFF
--- a/splunk/com/splunk/DeploymentServerClass.java
+++ b/splunk/com/splunk/DeploymentServerClass.java
@@ -209,25 +209,7 @@ public class DeploymentServerClass extends Entity {
      */
     public void setRepositoryLocation(String location) {
         setCacheValue("repositoryLocation", location);
-    }
 
-    /**
-     * Sets the location on the deployment client where the content that is 
-     * being deployed should be installed. 
-     *
-     * @param location The location (path) for installing content.
-     */
-    public void setTargetRepositoryLocation(String location) {
-        setCacheValue("targetRepositoryLocation", location);
-    }
-
-    /**
-     * Sets the working folder used by the deployment server.
-     *
-     * @param location The working folder.
-     */
-    public void setTmpFolder(String location) {
-        setCacheValue("tmpFolder", location);
     }
 
     /**

--- a/tests/com/splunk/DeploymentServerClassTest.java
+++ b/tests/com/splunk/DeploymentServerClassTest.java
@@ -132,20 +132,5 @@ public class DeploymentServerClassTest extends SDKTestCase {
         serverClass.refresh();
         assertEquals("blacklist", serverClass.getFilterType());
     }
-
-    @Test
-    public void testTargetRepositoryLocation() {
-        serverClass.setTargetRepositoryLocation("/nowhere");
-        serverClass.update();
-        serverClass.refresh();
-        assertEquals("/nowhere", serverClass.getTargetRepositoryLocation());
-    }
-
-    @Test public void testTmpFolder() {
-        serverClass.setTmpFolder("/nowhere");
-        serverClass.update();
-        serverClass.refresh();
-        assertEquals("/nowhere", serverClass.getTmpFolder());
-    }
 }
 


### PR DESCRIPTION
The REST API commands behind these seem to be broken: they work, but they leave Splunk in a state where it complains about the state of its configuration files. Whether they actually function in practice, I don't know. The tests on these two methods were also removed.

See DVPL-1293.
