### PR TITLE
Fix Command.load to close the FileReader at all times

### DIFF
--- a/util/com/splunk/Command.java
+++ b/util/com/splunk/Command.java
@@ -114,28 +114,38 @@ public class Command {
 
     // Load a file of options and arguments
     public Command load(String path) {
-        FileReader fileReader;
-        try {
-            fileReader = new FileReader(path);
-        }
-        catch (FileNotFoundException e) { return this; }
-
+        FileReader fileReader = null;
         ArrayList<String> argList = new ArrayList<String>(4);
-        BufferedReader reader = new BufferedReader(fileReader);
-        while (true) {
-            String line;
+
+        try{
             try {
-                line = reader.readLine();
+                fileReader = new FileReader(path);
             }
-            catch (IOException e) { return this; }
-            if (line == null) break;
-            if (line.startsWith("#")) continue;
-            line = line.trim();
-            if (line.length() == 0) continue;
-            if (!line.startsWith("-"))
-                line = "--" + line;
-            argList.add(line);
+            catch (FileNotFoundException e) { return this; }
+
+            BufferedReader reader = new BufferedReader(fileReader);
+            while (true) {
+                String line;
+                try {
+                    line = reader.readLine();
+                }
+                catch (IOException e) { return this; }
+                if (line == null) break;
+                if (line.startsWith("#")) continue;
+                line = line.trim();
+                if (line.length() == 0) continue;
+                if (!line.startsWith("-"))
+                    line = "--" + line;
+                argList.add(line);
+            }
+        } finally { 
+            if (null != fileReader) {
+                try {
+                    fileReader.close();
+                } catch (IOException e) { }
+            };
         }
+
         parse(argList.toArray(new String[argList.size()]));
         return this;
     }


### PR DESCRIPTION
https://github.com/areese/splunk-sdk-java/blob/areese-fix-Command-not-closing-inputstreams/util/com/splunk/Command.java

Fails to close FileReader.  :)

Here is a pull request to take care of that and to always close it in a finally block.
