### PR TITLE
JobCollection.list() hardcodes param ?count=-0

### DIFF
--- a/splunk/com/splunk/JobCollection.java
+++ b/splunk/com/splunk/JobCollection.java
@@ -117,7 +117,8 @@ public class JobCollection extends EntityCollection<Job> {
      * @return The job's response.
      */
     @Override public ResponseMessage list() {
-        return service.get(path + "?count=0");
+        this.refreshArgs.add("count", 0);
+        return service.get(path, this.refreshArgs);
     }
 
     /**


### PR DESCRIPTION
And that completely ignores any other params you put into the args object that you pass to getJobs().
