### PR TITLE
Allow setting the SSLSocketFactory, to avoid the SSLv3 security issue.

### DIFF
--- a/splunk/com/splunk/HttpService.java
+++ b/splunk/com/splunk/HttpService.java
@@ -35,8 +35,7 @@ import java.util.Map.Entry;
 public class HttpService {
     // For debugging purposes
     private static final boolean VERBOSE_REQUESTS = false;
-
-    private static final SSLSocketFactory SSL_SOCKET_FACTORY = createSSLFactory();
+    private static SSLSocketFactory sslSocketFactory = createDefaultSSLSocketFactory();
     
     private static String HTTPS_SCHEME = "https";
     private static String HTTP_SCHEME = "http";
@@ -277,7 +276,7 @@ public class HttpService {
      */
     Socket open() throws IOException {
         if (this.scheme.equals("https")) {
-            return SSL_SOCKET_FACTORY.createSocket(this.host, this.port);
+            return sslSocketFactory.createSocket(this.host, this.port);
         }
         return new Socket(this.host, this.port);
     }
@@ -303,7 +302,7 @@ public class HttpService {
             throw new RuntimeException(e.getMessage(), e);
         }
         if(cn instanceof HttpsURLConnection) {
-            ((HttpsURLConnection)cn).setSSLSocketFactory(SSL_SOCKET_FACTORY);
+            ((HttpsURLConnection)cn).setSSLSocketFactory(sslSocketFactory);
             ((HttpsURLConnection)cn).setHostnameVerifier(HOSTNAME_VERIFIER);
         }
         cn.setUseCaches(false);
@@ -388,7 +387,17 @@ public class HttpService {
         return response;
     }
 
-    private static SSLSocketFactory createSSLFactory() {
+    public static void setSSLSocketFactory(SSLSocketFactory sslSocketFactory){
+        if(sslSocketFactory == null)
+            throw new IllegalArgumentException("The SSLSocketFactory cannot be null.");
+        HttpService.sslSocketFactory = sslSocketFactory;
+    }
+
+    public static SSLSocketFactory getSSLSocketFactory(){
+        return HttpService.sslSocketFactory;
+    }
+
+    public static SSLSocketFactory createDefaultSSLSocketFactory() {
         TrustManager[] trustAll = new TrustManager[]{
                 new X509TrustManager() {
                     public X509Certificate[] getAcceptedIssuers() { return null; }

--- a/tests/com/splunk/HttpServiceTest.java
+++ b/tests/com/splunk/HttpServiceTest.java
@@ -19,7 +19,9 @@ package com.splunk;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
+import javax.net.ssl.SSLSocketFactory;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -28,6 +30,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 
 public class HttpServiceTest extends SDKTestCase {
@@ -85,5 +90,17 @@ public class HttpServiceTest extends SDKTestCase {
         ResponseMessage response = new ResponseMessage(200);
         Assert.assertEquals(response.getStatus(), 200);
         Assert.assertTrue(response.getHeader() != null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSSLSocketFactorySetNull(){
+        HttpService.setSSLSocketFactory(null);
+    }
+
+    @Test
+    public void testSSLSocketFactory(){
+        SSLSocketFactory factory = HttpService.createDefaultSSLSocketFactory();
+        HttpService.setSSLSocketFactory(factory);
+        Assert.assertSame(factory, HttpService.getSSLSocketFactory());
     }
 }


### PR DESCRIPTION
Allow the client consumer of the library to override the SSLSocketFactory, in order to use another protocols different from the flawed SSLv3.