### PR TITLE
Fix null namespaces

### DIFF
--- a/splunk/com/splunk/ResourceCollection.java
+++ b/splunk/com/splunk/ResourceCollection.java
@@ -259,6 +259,12 @@ public class ResourceCollection<T extends Resource>
 
         HashMap<String, String> entityMetadata =
                 (HashMap<String, String>)entry.content.get("eai:acl");
+        
+        // If there is no ACL info, we just create an empty map
+        if (entityMetadata == null) {
+        	entityMetadata = new HashMap<String, String>();
+        }        
+        
         if (entityMetadata.containsKey("owner"))
             namespace.put("owner", entityMetadata.get("owner"));
         if (entityMetadata.containsKey("app"))

--- a/splunk/com/splunk/ResourceCollection.java
+++ b/splunk/com/splunk/ResourceCollection.java
@@ -262,8 +262,8 @@ public class ResourceCollection<T extends Resource>
         
         // If there is no ACL info, we just create an empty map
         if (entityMetadata == null) {
-        	entityMetadata = new HashMap<String, String>();
-        }        
+            entityMetadata = new HashMap<String, String>();
+        }
         
         if (entityMetadata.containsKey("owner"))
             namespace.put("owner", entityMetadata.get("owner"));


### PR DESCRIPTION
There are conditions in SHC by which Splunk may not return proper namespacing information for some objects (mostly saved searches). This in turn causes
a break in an assumption that the SDK is making, so we need to properly
handle a case where the namespace info is empty.