### PR TITLE
Add support for multiple cookies

### DIFF
--- a/splunk/com/splunk/HttpService.java
+++ b/splunk/com/splunk/HttpService.java
@@ -479,13 +479,7 @@ public class HttpService {
         }
         
         // Add cookies to cookie Store
-        Map<String, List<String>> headers = cn.getHeaderFields();
-        if (headers.containsKey("Set-Cookie")) {
-            for (String val : headers.get("Set-Cookie")) {
-                cookieStore.add(val);
-            }
-        }
-        
+        Map<String, List<String>> headers = cn.getHeaderFields();        
         if (header.containsKey("Set-Cookie")) {
             for (String cookieHeader : headers.get("Set-Cookie")) {
                 cookieStore.add(cookieHeader);

--- a/splunk/com/splunk/HttpService.java
+++ b/splunk/com/splunk/HttpService.java
@@ -480,9 +480,10 @@ public class HttpService {
         
         // Add cookies to cookie Store
         Map<String, List<String>> headers = cn.getHeaderFields();        
-        if (header.containsKey("Set-Cookie")) {
+        if (headers.containsKey("Set-Cookie")) {
             for (String cookieHeader : headers.get("Set-Cookie")) {
-                cookieStore.add(cookieHeader);
+               if (cookieHeader != null && cookieHeader.length() > 0)
+                    cookieStore.add(cookieHeader);
             }
         }
 

--- a/splunk/com/splunk/HttpService.java
+++ b/splunk/com/splunk/HttpService.java
@@ -321,7 +321,7 @@ public class HttpService {
         this.readTimeout = readTimeout;
     }
 
-	/**
+    /**
      * Issues a POST request against the service using a given path.
      *
      * @param path The request path.
@@ -480,18 +480,15 @@ public class HttpService {
         
         // Add cookies to cookie Store
         Map<String, List<String>> headers = cn.getHeaderFields();
-        System.out.println("-----------KEYS-------------");
-    	if (headers.containsKey("Set-Cookie")) {
-    		System.out.print("\tvalues");
-    		for(String val : headers.get("Set-Cookie")) {
-    			System.out.print("\t*" + val);
-    			cookieStore.add(val);
-    		}
-    	}
+        if (headers.containsKey("Set-Cookie")) {
+            for (String val : headers.get("Set-Cookie")) {
+                cookieStore.add(val);
+            }
+        }
         
         if (header.containsKey("Set-Cookie")) {
-        	for (String cookieHeader : headers.get("Set-Cookie")) {
-        		cookieStore.add(cookieHeader);
+            for (String cookieHeader : headers.get("Set-Cookie")) {
+                cookieStore.add(cookieHeader);
             }
         }
 

--- a/splunk/com/splunk/HttpService.java
+++ b/splunk/com/splunk/HttpService.java
@@ -24,6 +24,7 @@ import java.io.OutputStreamWriter;
 import java.net.*;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -476,9 +477,23 @@ public class HttpService {
         } catch (IOException e) {
             assert (false);
         }
-
+        
         // Add cookies to cookie Store
-        cookieStore.add(cn.getHeaderField("Set-Cookie"));
+        Map<String, List<String>> headers = cn.getHeaderFields();
+        System.out.println("-----------KEYS-------------");
+    	if (headers.containsKey("Set-Cookie")) {
+    		System.out.print("\tvalues");
+    		for(String val : headers.get("Set-Cookie")) {
+    			System.out.print("\t*" + val);
+    			cookieStore.add(val);
+    		}
+    	}
+        
+        if (header.containsKey("Set-Cookie")) {
+        	for (String cookieHeader : headers.get("Set-Cookie")) {
+        		cookieStore.add(cookieHeader);
+            }
+        }
 
         ResponseMessage response = new ResponseMessage(status, input);
 

--- a/tests/com/splunk/CookieTest.java
+++ b/tests/com/splunk/CookieTest.java
@@ -16,12 +16,13 @@
 
 package com.splunk;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Assume;
-import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 public class CookieTest extends SDKTestCase {
 
@@ -119,6 +120,21 @@ public class CookieTest extends SDKTestCase {
         Service s  = new Service(args);
 
         s.addCookie("bad=cookie");
+
+        s.getSettings().refresh();
+    }
+
+    @Test
+    public void testLoginWithMultipleInvalidCookies() {
+        String validCookie = service.stringifyCookies();
+
+        Map<String, Object> args = getStandardArgs();
+
+        Service s  = new Service(args);
+
+        s.addCookie("bad=cookie");
+        s.addCookie(validCookie);
+        s.addCookie("another_bad=cookie");
 
         s.getSettings().refresh();
     }

--- a/tests/com/splunk/ServiceTest.java
+++ b/tests/com/splunk/ServiceTest.java
@@ -650,11 +650,7 @@ public class ServiceTest extends SDKTestCase {
         try {
             service.export("notasearchcommand", exportArgs);
         } catch (Exception e) {
-            Assert.assertEquals(
-                    "HTTP 400 -- {\"messages\":[{\"type\":\"FATAL\",\"text\":" +
-                            "\"Unknown search command 'notasearchcommand'.\"}]}",
-                    e.getMessage()
-            );
+        	Assert.assertTrue(e.getMessage().contains("Unknown search command"));
             return;
         }
         Assert.fail();


### PR DESCRIPTION
This should cover scenarios for search head clusters backed by load balancers that may insert additional cookies.

**This needs additional testing**