### PR TITLE
fix bug of java modular input launchers in windows may not kill java process when it be terminated

### DIFF
--- a/launchers/shim/shim/shim.cpp
+++ b/launchers/shim/shim/shim.cpp
@@ -25,6 +25,7 @@ int _tmain(int argc, _TCHAR* argv[])
     HANDLE processHandles[2] = {NULL, NULL};
     HANDLE &splunkdHandle = processHandles[0];
     HANDLE &jvmHandle = processHandles[1];
+    HANDLE ghJob = NULL;
     PTSTR jarPath = NULL, jvmOptions = NULL, jvmCommandLine = NULL;
     DWORD waitOutcome, exitCode;
 
@@ -49,7 +50,7 @@ int _tmain(int argc, _TCHAR* argv[])
     }
 
     // create a job
-    HANDLE ghJob = CreateJobObject(NULL, NULL);
+    ghJob = CreateJobObject(NULL, NULL);
     if(ghJob == NULL) {
         printErrorMessage(GetLastError());
 
@@ -120,6 +121,7 @@ CLEAN_UP_AND_EXIT:
 
     if (NULL != splunkdHandle) CloseHandle(splunkdHandle);
     if (NULL != jvmHandle)     CloseHandle(jvmHandle);
+    if (NULL != ghJob)         CloseHandle(ghJob);
 
     return returnCode;
 }


### PR DESCRIPTION
Resolve: #92 

I'm not very familiar with vc++ and windows process management. I try to create a job object and assign to this job. When this job handler destroyed, the java process will also be killed. 

I'm not sure I did the right thing but I verify it can work in windows. Correct me if I'm wrong. Thank you.