### PR TITLE
Fix bug of Value.toDate(string value) is not thread safe.

### DIFF
--- a/splunk/com/splunk/Value.java
+++ b/splunk/com/splunk/Value.java
@@ -80,7 +80,7 @@ class Value {
      * @param value Value to convert.
      * @return Date value.
      */
-    static Date toDate(String value) {
+    static synchronized Date toDate(String value) {
         if (dateFormat == null) {
             dateFormat = new SimpleDateFormat[6];
             dateFormat[0] = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");


### PR DESCRIPTION
Fix bug of Value.toDate(string value) is not thread safe.