### PR TITLE
Remove clear password assertions in POST tests

### DIFF
--- a/tests/com/splunk/PasswordTest.java
+++ b/tests/com/splunk/PasswordTest.java
@@ -53,14 +53,12 @@ public class PasswordTest extends SDKTestCase {
         password = passwords.create(name, value);
         Assert.assertTrue(passwords.containsKey(name));
         Assert.assertEquals(name, password.getUsername());
-        Assert.assertEquals(value, password.getClearPassword());
         Assert.assertEquals(null, password.getRealm());
 
         // Update the password
         password.update(new Args("password", "foobar"));
         Assert.assertTrue(passwords.containsKey(name));
         Assert.assertEquals(name, password.getUsername());
-        Assert.assertEquals("foobar", password.getClearPassword());
         Assert.assertEquals(null, password.getRealm());
 
         passwords.remove(name);
@@ -70,14 +68,12 @@ public class PasswordTest extends SDKTestCase {
         password = passwords.create(name, value, realm);
         Assert.assertTrue(passwords.containsKey(name));
         Assert.assertEquals(name, password.getUsername());
-        Assert.assertEquals(value, password.getClearPassword());
         Assert.assertEquals(realm, password.getRealm());
 
         // Update the password
         password.update(new Args("password", "bizbaz"));
         Assert.assertTrue(passwords.containsKey(name));
         Assert.assertEquals(name, password.getUsername());
-        Assert.assertEquals("bizbaz", password.getClearPassword());
         Assert.assertEquals(realm, password.getRealm());
 
         Assert.assertTrue(password.getEncryptedPassword().length() > 0);
@@ -105,8 +101,8 @@ public class PasswordTest extends SDKTestCase {
         passwords.create(username, passwordA, realmA);
         passwords.create(username, passwordB, realmB);
 
-        Assert.assertEquals(passwordA, passwords.get(realmA, username).getClearPassword());
-        Assert.assertEquals(passwordB, passwords.get(realmB, username).getClearPassword());
+        Assert.assertTrue(passwords.get(realmA, username).getEncryptedPassword().length() > 0);
+        Assert.assertTrue(passwords.get(realmB, username).getEncryptedPassword().length() > 0);
 
         passwords.remove(realmA, username);
         passwords.remove(realmB, username);
@@ -124,7 +120,7 @@ public class PasswordTest extends SDKTestCase {
         String username = "sdk-test-username";
 
         passwords.create(username, password, realm);
-        Assert.assertEquals(password, passwords.get(username).getClearPassword());
+        Assert.assertTrue(passwords.get(username).getEncryptedPassword().length() > 0);
 
         passwords.remove(username);
         Assert.assertNull(passwords.get(username));


### PR DESCRIPTION
POST requests to the /storage/passwords endpoint should not return the clear_password back in plaintext. Therefore, the references to getClearPassword() in the POST tests should be removed.

For the tests that specifically check the contents of the plaintext password, such as testPasswordsSameNamesButUniqueRealms() and testPasswordsCompatibleGetByName(), I changed it so they will just assert that the encryptedPassword exists.