### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ addons:
       - ant-optional
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk7
 
 before_script:


### PR DESCRIPTION
Fixed the Travis Failing Builds. Oracle JDK 8 is no longer available, so you have to use open JDK to make the builds still work with the older version.

https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038
https://talk.openmrs.org/t/travis-fails-to-build-project-abnomally/23165/2