### PR TITLE
Update test matrix to include latest 8.1 Splunk build and openjdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ before_install:
 language: java
 
 env:
-  - SPLUNK_VERSION=7.3
   - SPLUNK_VERSION=8.0
+  - SPLUNK_VERSION=8.1
 
 addons:
   apt:
@@ -36,7 +36,7 @@ addons:
       - ant-optional
 
 jdk:
-  - openjdk8
+  - openjdk9
 
 before_script:
     - ant


### PR DESCRIPTION
Update test matrix to include latest 8.1 Splunk build and openjdk9