### PR TITLE
Deploy plugin is removed from splunk module.

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,6 +21,7 @@
                     <skipTests>true</skipTests>
                 </configuration>
             </plugin>
+            <!-- Deploy plugin is overridden here because we are skipping deployment in case of examples module. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -91,14 +91,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0-M1</version>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
**Update:**

- Deploy plugin for splunk module removed and it will use its parent plugin for deployment. (Refer Issue #170 )
- Supporting comment has been added in examples/pom.xml file as we have skipped deployment there.