### PR TITLE
Remove dependency on maven-deploy-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,6 @@
             <artifactId>opencsv</artifactId>
             <version>2.3</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.0.0-M1</version>
-            <type>maven-plugin</type>
-        </dependency>
     </dependencies>
     <modules>
         <module>splunk</module>


### PR DESCRIPTION
I am building a project with this sdk and found it surprising that maven-deploy-plugin showed up on the dependency list. Could we remove it please?