### PR TITLE
Added feature to add custom headers to Service

### DIFF
--- a/splunk/src/main/java/com/splunk/HttpService.java
+++ b/splunk/src/main/java/com/splunk/HttpService.java
@@ -23,16 +23,11 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.*;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.Set;
 
 /**
  * The {@code HttpService} class represents a generic HTTP service at a given
@@ -85,13 +80,6 @@ public class HttpService {
 
     private String prefix = null;
 
-    private static final Set<String> filtertHttpHeaderKeys = Collections.unmodifiableSet(
-    		new HashSet<String>(Arrays.asList(
-    				"User-Agent",
-    				"Accept"
-    		))
-    );
-    
     static Map<String, String> defaultHeader = new HashMap<String, String>() {{
         put("User-Agent", "splunk-sdk-java/1.7.1");
         put("Accept", "*/*");
@@ -215,12 +203,8 @@ public class HttpService {
      * @param headers
      */
     public void setCustomHeaders(Map<String, String> headers) {
-    	if (Objects.nonNull(headers) && !headers.isEmpty()) {
-    		Map<String, String> fitleredCustomHeaders = headers.entrySet()
-    				.stream()
-    				.filter(e -> !filtertHttpHeaderKeys.contains(e.getKey()))
-    				.collect(Collectors.toMap(map -> map.getKey(), map -> map.getValue()));
-    		customHeaders.putAll(fitleredCustomHeaders);
+    	if (Objects.nonNull(headers)) {
+    		customHeaders = headers;
     	}
     }
 

--- a/splunk/src/main/java/com/splunk/Service.java
+++ b/splunk/src/main/java/com/splunk/Service.java
@@ -152,6 +152,7 @@ public class Service extends BaseService {
         this.httpsHandler = Args.<URLStreamHandler>get(args, "httpsHandler", null);
         this.setSslSecurityProtocol(Args.get(args, "SSLSecurityProtocol", Service.getSslSecurityProtocol()));
         this.addCookie((String)args.get("cookie"));
+        this.setCustomHeaders((Map<String, String>) args.get("customHeaders"));
     }
 
     /**

--- a/splunk/src/main/java/com/splunk/ServiceArgs.java
+++ b/splunk/src/main/java/com/splunk/ServiceArgs.java
@@ -17,6 +17,7 @@
 package com.splunk;
 
 import java.net.URLStreamHandler;
+import java.util.Map;
 
 /**
  * The {@code ServiceArgs} class contains a collection of arguments that are
@@ -163,5 +164,13 @@ public class ServiceArgs extends Args {
      */
     public void setCookie(String cookie) {
         this.put("cookie", cookie);
+    }
+    
+    /**
+     * @param httpHeaders
+     *     A map of customHeaders.
+     */
+    public void setHttpHeaders(Map<String, String> httpHeaders) {
+    	this.put("customHeaders", httpHeaders);
     }
 }

--- a/splunk/src/test/java/com/splunk/ServiceTest.java
+++ b/splunk/src/test/java/com/splunk/ServiceTest.java
@@ -146,7 +146,23 @@ public class ServiceTest extends SDKTestCase {
         service.logout();
         checkNotLoggedIn(service);
     }
-
+    
+    @Test
+    public void testServiceWithCustomHeaders() {
+    	ServiceArgs args = new ServiceArgs();
+    	args.setHost((String) command.opts.get("host"));
+    	args.setPort((Integer) command.opts.get("port"));
+    	args.setScheme((String) command.opts.get("scheme"));
+    	args.setUsername((String) command.opts.get("username"));
+    	args.setPassword((String) command.opts.get("password"));
+    	args.setHttpHeaders(new HashMap<String, String>() {{
+    		put("some header key", "some value");
+    	}});
+        Service service = new Service(args);
+        Map<String, String> customHeaders = service.getCustomHeaders();
+        Assert.assertEquals(customHeaders.get("some header key"), "some value");
+    }
+    
     @Test
     public void testLoginWithoutArguments() {
         ServiceArgs args = new ServiceArgs();


### PR DESCRIPTION
#### References to other Issues or PRs
Ref #169

#### Brief description of what is fixed or changed

1. Added support to add custom headers in Service
2. Implemented method setHttpHeaders which accepts a headers map
3. Created method setCustomHeaders in HttpService.java to filter and store the map key-values
4. Finally in send method of HttpService.java the customHeaders are added

#### Other comments
Rather than merging the custom map with the default one, I created a new protected variable to store the custom map
values. Please let me know if this is correct or not.