### PR TITLE
External Entities restricted in XML factory.

### DIFF
--- a/splunk/src/main/java/com/splunk/Xml.java
+++ b/splunk/src/main/java/com/splunk/Xml.java
@@ -52,6 +52,10 @@ public class Xml {
         try {
             DocumentBuilderFactory factory =
                 DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setExpandEntityReferences(false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             factory.setNamespaceAware(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             if (silent)

--- a/splunk/src/main/java/com/splunk/modularinput/InputDefinition.java
+++ b/splunk/src/main/java/com/splunk/modularinput/InputDefinition.java
@@ -175,6 +175,10 @@ public class InputDefinition {
             IOException, SAXException, MalformedDataException {
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         documentBuilderFactory.setIgnoringElementContentWhitespace(true);
+        documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        documentBuilderFactory.setExpandEntityReferences(false);
+        documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
         Document doc = documentBuilder.parse(stream);
 

--- a/splunk/src/main/java/com/splunk/modularinput/ValidationDefinition.java
+++ b/splunk/src/main/java/com/splunk/modularinput/ValidationDefinition.java
@@ -194,6 +194,10 @@ public class ValidationDefinition {
             IOException, SAXException, MalformedDataException {
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         documentBuilderFactory.setIgnoringElementContentWhitespace(true);
+        documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        documentBuilderFactory.setExpandEntityReferences(false);
+        documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
         Document doc = documentBuilder.parse(stream);
 


### PR DESCRIPTION
**Update:**

- By default, document builder factory xml parsers allows expansion of external entities. So to prevent attackers to forge malicious content using external entities, these features are added.