### PR TITLE
API docs upload automated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           server-id: splunk-artifactory
       - name: build
         run: mvn package --file pom.xml -DskipTests=true
+      - name: Create temp artifacts apidocs folder
+        run: mkdir apidocs
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
@@ -32,3 +34,12 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
+      - name: Zip docs
+        run: zip -r apidocs/docs.zip splunk/target/apidocs
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: apidocs
+          path: apidocs/docs.zip


### PR DESCRIPTION
**Update:**
- While release, api docs will be generated and compressed using zip tool.
- Using **upload-artifact** github-action module, it will allow us to download generated api docs zip till 90 days.