### PR TITLE
Storagepassword's wildcard check for create and delete actions

### DIFF
--- a/splunk/src/main/java/com/splunk/PasswordCollection.java
+++ b/splunk/src/main/java/com/splunk/PasswordCollection.java
@@ -144,7 +144,7 @@ public class PasswordCollection extends EntityCollection<Password> {
 
     private Boolean checkForWildcards(){
         Boolean isWildCard = false;
-        if(service.getOwner().equals("-") || service.getApp().equals("-")){
+        if(("-").equals(service.getOwner()) || ("-").equals(service.getApp())){
             isWildCard = true;
         }
         return isWildCard;

--- a/splunk/src/main/java/com/splunk/PasswordCollection.java
+++ b/splunk/src/main/java/com/splunk/PasswordCollection.java
@@ -142,8 +142,8 @@ public class PasswordCollection extends EntityCollection<Password> {
         return null;
     }
 
-    private Boolean checkForWildcards(){
-        Boolean isWildCard = false;
+    private boolean checkForWildcards(){
+        boolean isWildCard = false;
         if(("-").equals(service.getOwner()) || ("-").equals(service.getApp())){
             isWildCard = true;
         }

--- a/splunk/src/main/java/com/splunk/PasswordCollection.java
+++ b/splunk/src/main/java/com/splunk/PasswordCollection.java
@@ -50,6 +50,9 @@ public class PasswordCollection extends EntityCollection<Password> {
      * @return The new credential.
      */
     public Password create(String name, String password) {
+        if(checkForWildcards()){
+            throw new IllegalArgumentException("While creating StoragePasswords, namespace cannot have wildcards.");
+        }
         Args args = new Args("password", password);
         return create(name, args);
     }
@@ -63,6 +66,9 @@ public class PasswordCollection extends EntityCollection<Password> {
      * @return The new credential.
      */
     public Password create(String name, String password, String realm) {
+        if(checkForWildcards()){
+            throw new IllegalArgumentException("While creating StoragePasswords, namespace cannot have wildcards.");
+        }
         Args args = new Args();
         args.put("password", password);
         args.put("realm", realm);
@@ -97,11 +103,17 @@ public class PasswordCollection extends EntityCollection<Password> {
      * @return The removed credential, or null if not found.
      */
     public Password remove(String realm, String name) {
+        if(checkForWildcards()){
+            throw new IllegalArgumentException("app context must be specified when removing a password.");
+        }
         return super.remove(String.format("%s:%s:", realm, name));
     }
 
     @Override
     public Password remove(String key) {
+        if(checkForWildcards()){
+            throw new IllegalArgumentException("app context must be specified when removing a password.");
+        }
         // Make it compatible with the old way (low-efficient)
         if (!key.contains(":")) {
             Password password = getByUsername((String) key);
@@ -128,5 +140,13 @@ public class PasswordCollection extends EntityCollection<Password> {
             if (password.getUsername().equals(name)) return password;
         }
         return null;
+    }
+
+    private Boolean checkForWildcards(){
+        Boolean isWildCard = false;
+        if(service.getOwner().equals("-") || service.getApp().equals("-")){
+            isWildCard = true;
+        }
+        return isWildCard;
     }
 }

--- a/splunk/src/test/java/com/splunk/PasswordTest.java
+++ b/splunk/src/test/java/com/splunk/PasswordTest.java
@@ -19,6 +19,8 @@ package com.splunk;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
+
 public class PasswordTest extends SDKTestCase {
     @Test
     public void testGettersOfDefaultPasswords() {
@@ -128,5 +130,47 @@ public class PasswordTest extends SDKTestCase {
 
         passwords.remove(username);
         Assert.assertNull(passwords.get(username));
+    }
+    @Test
+    public void testPasswordsCrudWithWildCards(){
+        HashMap<String, Object> args = new HashMap<String, Object>();
+        args = Command.defaultValues;
+        args.put("owner", "-");
+        args.put("app", "-");
+        args.put("username", "admin");
+        args.put("password", "changed!");
+        Service service = Service.connect(args);
+        PasswordCollection passwords = service.getPasswords();
+        Assert.assertEquals(passwords.size(),0);
+
+        String name = "no-owner";
+        String value = "sdk-test-password";
+        String realm = "sdk-test-realm";
+
+        Password password;
+        // Create a password
+        try{
+            password = passwords.create(name, value);
+        }catch(IllegalArgumentException e){
+            Assert.assertEquals("While creating StoragePasswords, namespace cannot have wildcards.", e.getMessage());
+        }
+        try{
+            password = passwords.create(name, value, realm);
+        }catch(IllegalArgumentException e){
+            Assert.assertEquals("While creating StoragePasswords, namespace cannot have wildcards.", e.getMessage());
+        }
+        // Remove a password
+        try{
+            password = passwords.remove(name);
+        }catch(IllegalArgumentException e){
+            Assert.assertEquals("app context must be specified when removing a password.", e.getMessage());
+        }
+        try{
+            password = passwords.remove(realm, name);
+        }catch(IllegalArgumentException e){
+            Assert.assertEquals("app context must be specified when removing a password.", e.getMessage());
+        }
+        passwords = service.getPasswords();
+        Assert.assertEquals(passwords.size(),0);
     }
 }

--- a/splunk/src/test/java/com/splunk/PasswordTest.java
+++ b/splunk/src/test/java/com/splunk/PasswordTest.java
@@ -132,7 +132,7 @@ public class PasswordTest extends SDKTestCase {
         Assert.assertNull(passwords.get(username));
     }
     @Test
-    public void testPasswordsCrudWithWildCards(){
+    public void testPasswordsWithWildCards(){
         HashMap<String, Object> args = new HashMap<String, Object>();
         args = Command.defaultValues;
         args.put("owner", "-");


### PR DESCRIPTION
Added check for presence of wildcard's in 'owner' and/or 'app' while creating or deleting a StoragePassword. Check and error message is kept consistent with the other SDKs.