### PR TITLE
SDK Support for splunkd search API changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           server-id: splunk-artifactory
       - name: build
         run: mvn package --file pom.xml -DskipTests=true
+      - name: Create temp artifacts apidocs folder
+        run: mkdir apidocs
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
@@ -32,3 +34,12 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
+      - name: Zip docs
+        run: zip -r apidocs/docs.zip splunk/target/apidocs
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: apidocs
+          path: apidocs/docs.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         java-version:
           - 1.8
         splunk-version:
-          - "8.0"
+          - "8.2"
           - "latest"
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Here's what you need to get going with the Splunk SDK for Java.
 If you haven't already installed Splunk, download it
 [here](http://www.splunk.com/download). For more about installing and running
 Splunk and system requirements, see
-[Installing & Running Splunk](http://dev.splunk.com/view/SP-CAAADRV). The Splunk SDK for Java has been tested with Splunk Enterprise 8.0 and 8.2.0.
+[Installing & Running Splunk](http://dev.splunk.com/view/SP-CAAADRV). The Splunk SDK for Java has been tested with Splunk Enterprise 9.0 and 8.2.
 
 #### Splunk SDK for Java
 

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <goals>

--- a/splunk/src/main/java/com/splunk/HttpService.java
+++ b/splunk/src/main/java/com/splunk/HttpService.java
@@ -208,7 +208,7 @@ public class HttpService {
     /**
      * Sets Custom Headers of this service
      * 
-     * @param headers
+     * @param headers The custom headers.
      */
     public void setCustomHeaders(Map<String, String> headers) {
     	if (Objects.nonNull(headers)) {

--- a/splunk/src/main/java/com/splunk/Job.java
+++ b/splunk/src/main/java/com/splunk/Job.java
@@ -29,15 +29,18 @@ import java.util.Map;
 public class Job extends Entity {
 
     private boolean isReady = false;
+    private String sid;
 
     /**
      * Class constructor.
      *
      * @param service The connected {@code Service} instance.
      * @param path The search jobs endpoint.
+     * @param sid The sid of the job.
      */
-    Job(Service service, String path) {
+    Job(Service service, String path, String sid) {
         super(service, path);
+        this.sid = sid;
     }
 
     /**
@@ -366,12 +369,17 @@ public class Job extends Entity {
             // search terms (i.e., <sg> elements in XML output).
             args.put("segmentation", "none");
         }
-        if (args.containsKey("search")) {
-            // Remove the search request parameter if it exists
-            args.remove("search");
+
+        // Splunk version doesn't support v2 (pre-9.0) or the 'search' arg is included (which is v1 specific)
+        String fullPath;
+        if (service.versionIsEarlierThan("9.0") || args.containsKey("search")) {
+            fullPath = JobCollection.REST_PATH + sid + methodPath;
+        }
+        else {
+            fullPath = JobCollection.REST_PATH_V2 + sid + methodPath;
         }
 
-        ResponseMessage response = service.get(path + methodPath, args);
+        ResponseMessage response = service.get(fullPath, args);
         return response.getContent();
     }
 

--- a/splunk/src/main/java/com/splunk/Job.java
+++ b/splunk/src/main/java/com/splunk/Job.java
@@ -29,7 +29,6 @@ import java.util.Map;
 public class Job extends Entity {
 
     private boolean isReady = false;
-    private String sid;
 
     /**
      * Class constructor.
@@ -38,9 +37,8 @@ public class Job extends Entity {
      * @param path The search jobs endpoint.
      * @param sid The sid of the job.
      */
-    Job(Service service, String path, String sid) {
+    Job(Service service, String path) {
         super(service, path);
-        this.sid = sid;
     }
 
     /**
@@ -373,10 +371,10 @@ public class Job extends Entity {
         // Splunk version doesn't support v2 (pre-9.0) or the 'search' arg is included (which is v1 specific)
         String fullPath;
         if (service.versionIsEarlierThan("9.0") || args.containsKey("search")) {
-            fullPath = JobCollection.REST_PATH + sid + methodPath;
+            fullPath = path.replace(JobCollection.REST_PATH_V2, JobCollection.REST_PATH) + methodPath;
         }
         else {
-            fullPath = JobCollection.REST_PATH_V2 + sid + methodPath;
+            fullPath = path.replace(JobCollection.REST_PATH, JobCollection.REST_PATH_V2) + methodPath;
         }
 
         ResponseMessage response = service.get(fullPath, args);

--- a/splunk/src/main/java/com/splunk/Job.java
+++ b/splunk/src/main/java/com/splunk/Job.java
@@ -368,16 +368,19 @@ public class Job extends Entity {
             args.put("segmentation", "none");
         }
 
-        // Splunk version doesn't support v2 (pre-9.0) or the 'search' arg is included (which is v1 specific)
+        // Splunk version pre-9.0 doesn't support v2
+        // v1(GET), v2(POST)
         String fullPath;
-        if (service.versionIsEarlierThan("9.0") || args.containsKey("search")) {
+        ResponseMessage response;
+        if (service.versionIsEarlierThan("9.0")) {
             fullPath = path.replace(JobCollection.REST_PATH_V2, JobCollection.REST_PATH) + methodPath;
+            response = service.get(fullPath, args);
         }
         else {
             fullPath = path.replace(JobCollection.REST_PATH, JobCollection.REST_PATH_V2) + methodPath;
+            response = service.post(fullPath, args);
         }
 
-        ResponseMessage response = service.get(fullPath, args);
         return response.getContent();
     }
 

--- a/splunk/src/main/java/com/splunk/Job.java
+++ b/splunk/src/main/java/com/splunk/Job.java
@@ -366,6 +366,10 @@ public class Job extends Entity {
             // search terms (i.e., <sg> elements in XML output).
             args.put("segmentation", "none");
         }
+        if (args.containsKey("search")) {
+            // Remove the search request parameter if it exists
+            args.remove("search");
+        }
 
         ResponseMessage response = service.get(path + methodPath, args);
         return response.getContent();

--- a/splunk/src/main/java/com/splunk/JobCollection.java
+++ b/splunk/src/main/java/com/splunk/JobCollection.java
@@ -27,13 +27,14 @@ public class JobCollection extends EntityCollection<Job> {
     static String oneShotNotAllowed = String.format(
          "Oneshot not allowed, use service oneshot search method");
     static final String REST_PATH = "search/jobs";
+    static final String REST_PATH_V2 = "search/v2/jobs";
     /**
      * Class constructor.
      *
      * @param service The connected {@code Service} instance.
      */
     JobCollection(Service service) {
-        super(service, REST_PATH, Job.class);
+        super(service, service.versionIsAtLeast("9.0") ? REST_PATH_V2 : REST_PATH, Job.class);
         this.refreshArgs.put("count", "0");
     }
 
@@ -45,7 +46,7 @@ public class JobCollection extends EntityCollection<Job> {
      * return and how to sort them (see {@link CollectionArgs}).
      */
     JobCollection(Service service, Args args) {
-        super(service, REST_PATH, Job.class, args);
+        super(service, service.versionIsAtLeast("9.0") ? REST_PATH_V2 : REST_PATH, Job.class, args);
         this.refreshArgs.put("count", "0");
     }
 
@@ -86,7 +87,8 @@ public class JobCollection extends EntityCollection<Job> {
             .item(0)
             .getTextContent();
 
-        Job job = new Job(service, REST_PATH + "/" + sid);
+        String path = service.versionIsAtLeast("9.0") ? REST_PATH_V2 : REST_PATH;
+        Job job = new Job(service, path + "/" + sid);
         job.refresh();
 
         return job;

--- a/splunk/src/main/java/com/splunk/JobCollection.java
+++ b/splunk/src/main/java/com/splunk/JobCollection.java
@@ -88,7 +88,7 @@ public class JobCollection extends EntityCollection<Job> {
             .getTextContent();
 
         String path = service.versionIsAtLeast("9.0") ? REST_PATH_V2 : REST_PATH;
-        Job job = new Job(service, path + "/" + sid, sid);
+        Job job = new Job(service, path + "/" + sid);
         job.refresh();
 
         return job;

--- a/splunk/src/main/java/com/splunk/JobCollection.java
+++ b/splunk/src/main/java/com/splunk/JobCollection.java
@@ -88,7 +88,7 @@ public class JobCollection extends EntityCollection<Job> {
             .getTextContent();
 
         String path = service.versionIsAtLeast("9.0") ? REST_PATH_V2 : REST_PATH;
-        Job job = new Job(service, path + "/" + sid);
+        Job job = new Job(service, path + "/" + sid, sid);
         job.refresh();
 
         return job;

--- a/splunk/src/main/java/com/splunk/OutputServer.java
+++ b/splunk/src/main/java/com/splunk/OutputServer.java
@@ -92,7 +92,7 @@ public class OutputServer extends Entity {
     /**
      *  Returns client certificate path.
      *
-     * @return
+     * @return Path of client certificate.
      */
     public String getClientCert() {
         return getString("clientCert", "");

--- a/splunk/src/main/java/com/splunk/SavedSearch.java
+++ b/splunk/src/main/java/com/splunk/SavedSearch.java
@@ -88,7 +88,7 @@ public class SavedSearch extends Entity {
 
         // if job not yet scheduled, create an empty job object
         if (job == null) {
-            job = new Job(service, JobCollection.REST_PATH + "/" + sid);
+            job = new Job(service, JobCollection.REST_PATH + "/" + sid, sid);
         }
 
         return job;
@@ -124,7 +124,7 @@ public class SavedSearch extends Entity {
         Job[] result = new Job[count];
         for (int i = 0; i < count; ++i) {
             String sid = feed.entries.get(i).title;
-            result[i] = new Job(service, JobCollection.REST_PATH + "/" + sid);
+            result[i] = new Job(service, JobCollection.REST_PATH + "/" + sid, sid);
         }
         return result;
     }

--- a/splunk/src/main/java/com/splunk/SavedSearch.java
+++ b/splunk/src/main/java/com/splunk/SavedSearch.java
@@ -88,7 +88,7 @@ public class SavedSearch extends Entity {
 
         // if job not yet scheduled, create an empty job object
         if (job == null) {
-            job = new Job(service, JobCollection.REST_PATH + "/" + sid, sid);
+            job = new Job(service, JobCollection.REST_PATH + "/" + sid);
         }
 
         return job;
@@ -124,7 +124,7 @@ public class SavedSearch extends Entity {
         Job[] result = new Job[count];
         for (int i = 0; i < count; ++i) {
             String sid = feed.entries.get(i).title;
-            result[i] = new Job(service, JobCollection.REST_PATH + "/" + sid, sid);
+            result[i] = new Job(service, JobCollection.REST_PATH + "/" + sid);
         }
         return result;
     }

--- a/splunk/src/main/java/com/splunk/Service.java
+++ b/splunk/src/main/java/com/splunk/Service.java
@@ -651,7 +651,7 @@ public class Service extends BaseService {
      * @return A Job.
      */
     public Job getJob(String sid) {
-        return new Job(this, JobCollection.REST_PATH + "/" + sid, sid);
+        return new Job(this, JobCollection.REST_PATH + "/" + sid);
     }
 
     /**

--- a/splunk/src/main/java/com/splunk/Service.java
+++ b/splunk/src/main/java/com/splunk/Service.java
@@ -1251,7 +1251,7 @@ public class Service extends BaseService {
      */
     public ResponseMessage parse(String query, Map args) {
         args = Args.create(args).add("q", query);
-        return get("search/parser", args);
+        return post("search/parser", args);
     }
 
     /**

--- a/splunk/src/main/java/com/splunk/Service.java
+++ b/splunk/src/main/java/com/splunk/Service.java
@@ -651,7 +651,7 @@ public class Service extends BaseService {
      * @return A Job.
      */
     public Job getJob(String sid) {
-        return new Job(this, JobCollection.REST_PATH + "/" + sid);
+        return new Job(this, JobCollection.REST_PATH + "/" + sid, sid);
     }
 
     /**

--- a/splunk/src/main/java/com/splunk/Service.java
+++ b/splunk/src/main/java/com/splunk/Service.java
@@ -223,7 +223,13 @@ public class Service extends BaseService {
         if (!args.containsKey("segmentation")) {
             args.put("segmentation", "none");
         }
-        ResponseMessage response = post(JobCollection.REST_PATH + "/export", args);
+        ResponseMessage response;
+
+        if (versionIsAtLeast("9.0"))
+            response = post(JobCollection.REST_PATH_V2 + "/export", args);
+        else {
+            response = post(JobCollection.REST_PATH + "/export", args);
+        }
         return new ExportResultsStream(response.getContent());
     }
 
@@ -1251,7 +1257,11 @@ public class Service extends BaseService {
      */
     public ResponseMessage parse(String query, Map args) {
         args = Args.create(args).add("q", query);
-        return post("search/parser", args);
+
+        if (versionIsAtLeast("9.0"))
+            return post("search/v2/parser", args);
+        else
+            return get("search/parser", args);
     }
 
     /**

--- a/splunk/src/main/java/com/splunk/Service.java
+++ b/splunk/src/main/java/com/splunk/Service.java
@@ -223,7 +223,7 @@ public class Service extends BaseService {
         if (!args.containsKey("segmentation")) {
             args.put("segmentation", "none");
         }
-        ResponseMessage response = get(JobCollection.REST_PATH + "/export", args);
+        ResponseMessage response = post(JobCollection.REST_PATH + "/export", args);
         return new ExportResultsStream(response.getContent());
     }
 

--- a/splunk/src/test/java/com/splunk/SearchJobTest.java
+++ b/splunk/src/test/java/com/splunk/SearchJobTest.java
@@ -63,7 +63,7 @@ public class SearchJobTest extends SDKTestCase {
     }
 
     @Test
-    public void testEventsFromJobV1Fallback() {
+    public void testEventsWithSearchParams() {
         Job job = jobs.create(QUERY);
         waitUntilDone(job);
 
@@ -85,7 +85,7 @@ public class SearchJobTest extends SDKTestCase {
     }
 
     @Test
-    public void testResultsFromJobV1Fallback() {
+    public void testResultsWithSearchParams() {
         Job job = jobs.create(QUERY);
         waitUntilDone(job);
 
@@ -609,7 +609,7 @@ public class SearchJobTest extends SDKTestCase {
     }
 
     @Test
-    public void testPreviewV1Fallback() throws InterruptedException {
+    public void testPreviewWithSearchParams() throws InterruptedException {
         JobArgs args = new JobArgs();
         args.put("field_list", "source,host,sourcetype");
         args.setStatusBuckets(100);

--- a/splunk/src/test/java/com/splunk/SearchJobTest.java
+++ b/splunk/src/test/java/com/splunk/SearchJobTest.java
@@ -63,11 +63,35 @@ public class SearchJobTest extends SDKTestCase {
     }
 
     @Test
+    public void testEventsFromJobV1Fallback() {
+        Job job = jobs.create(QUERY);
+        waitUntilDone(job);
+
+        Map args = new HashMap<String, Object>();
+        args.put("search","| head 1");
+        Assert.assertEquals(1, countEvents(job.getEvents(args)));
+
+        job.cancel();
+    }
+
+    @Test
     public void testResultsFromJob() {
         Job job = jobs.create(QUERY);
         waitUntilDone(job);
 
         Assert.assertEquals(10, countEvents(job.getResults()));
+
+        job.cancel();
+    }
+
+    @Test
+    public void testResultsFromJobV1Fallback() {
+        Job job = jobs.create(QUERY);
+        waitUntilDone(job);
+
+        Map args = new HashMap<String, Object>();
+        args.put("search","| head 1");
+        Assert.assertEquals(1, countEvents(job.getResults(args)));
 
         job.cancel();
     }
@@ -580,6 +604,26 @@ public class SearchJobTest extends SDKTestCase {
         }
 
         Assert.assertTrue(10 >= countEvents(job.getResultsPreview()));
+
+        job.cancel();
+    }
+
+    @Test
+    public void testPreviewV1Fallback() throws InterruptedException {
+        JobArgs args = new JobArgs();
+        args.put("field_list", "source,host,sourcetype");
+        args.setStatusBuckets(100);
+
+        Job job = jobs.create(QUERY, args);
+
+        while (!job.isReady()) {
+            Thread.sleep(100);
+        }
+
+        Map argsSearchQuery = new HashMap<String, Object>();
+        argsSearchQuery.put("search","| head 1");
+        // Assert.assertTrue(1 >= countEvents(job.getResultsPreview(args)));
+        Assert.assertEquals(1, countEvents(job.getResultsPreview(argsSearchQuery)));
 
         job.cancel();
     }


### PR DESCRIPTION
In Splunk 9.0 new changes to certain search endpoints are added via v2 endpoints and changes from GET to POST. SDK detects whether 9.x or later is being used and uses v2 endpoints if so.