### PR TITLE
Persist cookies

### DIFF
--- a/splunk/src/main/java/com/splunk/HttpService.java
+++ b/splunk/src/main/java/com/splunk/HttpService.java
@@ -316,12 +316,12 @@ public class HttpService {
     }
 
     /**
-     * Returns true if the cookeStore has any cookies, false otherwise
+     * Returns true if the cookieStore has any Splunk Authorization cookies, false otherwise
      *
      * @return True if there are cookies, false otherwise
      */
-    public Boolean hasCookies() {
-        return !cookieStore.isEmpty();
+    public Boolean hasSplunkAuthCookies() {
+        return cookieStore.hasSplunkAuthCookie();
     }
 
     /**

--- a/splunk/src/main/java/com/splunk/Receiver.java
+++ b/splunk/src/main/java/com/splunk/Receiver.java
@@ -98,9 +98,13 @@ public class Receiver {
         headers.add("Accept-Encoding: identity");
         headers.add("X-Splunk-Input-Mode: Streaming");
 
-        if (service.hasCookies()) {
+        if (service.hasSplunkAuthCookies()) {
             headers.add(String.format("Cookie: %s", service.stringifyCookies()));
         } else {
+            // to persist the cookies other than Splunk such as from Load Balancer
+            if(!service.cookieStore.isEmpty()){
+                headers.add(String.format("Cookie: %s", service.stringifyCookies()));
+            }
             headers.add(String.format("Authorization: %s", service.getToken()));
         }
         headers.add("");

--- a/splunk/src/main/java/com/splunk/Service.java
+++ b/splunk/src/main/java/com/splunk/Service.java
@@ -1112,7 +1112,6 @@ public class Service extends BaseService {
      * @return The current {@code Service} instance.
      */
     public Service login() {
-        //if (!this.cookieStore.isEmpty() && (this.username == null || this.password == null)) {
         if (this.cookieStore.hasSplunkAuthCookie() && (this.username == null || this.password == null)) {
             return this;
         }
@@ -1313,7 +1312,6 @@ public class Service extends BaseService {
      */
     @Override public ResponseMessage send(String path, RequestMessage request) {
         // cookieStore is a protected member of HttpService
-        //if (token != null && cookieStore.isEmpty() ) {
         if (token != null && !cookieStore.hasSplunkAuthCookie() ) {
             request.getHeader().put("Authorization", token);
         }

--- a/splunk/src/main/java/com/splunk/Service.java
+++ b/splunk/src/main/java/com/splunk/Service.java
@@ -1112,7 +1112,8 @@ public class Service extends BaseService {
      * @return The current {@code Service} instance.
      */
     public Service login() {
-        if (!this.cookieStore.isEmpty() && (this.username == null || this.password == null)) {
+        //if (!this.cookieStore.isEmpty() && (this.username == null || this.password == null)) {
+        if (this.cookieStore.hasSplunkAuthCookie() && (this.username == null || this.password == null)) {
             return this;
         }
         else if (this.username == null || this.password == null) {
@@ -1312,7 +1313,8 @@ public class Service extends BaseService {
      */
     @Override public ResponseMessage send(String path, RequestMessage request) {
         // cookieStore is a protected member of HttpService
-        if (token != null && cookieStore.isEmpty()) {
+        //if (token != null && cookieStore.isEmpty() ) {
+        if (token != null && !cookieStore.hasSplunkAuthCookie() ) {
             request.getHeader().put("Authorization", token);
         }
         return super.send(fullpath(path), request);

--- a/splunk/src/main/java/com/splunk/SimpleCookieStore.java
+++ b/splunk/src/main/java/com/splunk/SimpleCookieStore.java
@@ -77,7 +77,6 @@ class SimpleCookieStore {
         }
         for(String cookie : cookieJar.keySet()){
             if(cookie.startsWith(SPLUNK_AUTH_COOKIE)){
-                System.out.println("HELLO");
                 return true;
             }
         }

--- a/splunk/src/main/java/com/splunk/SimpleCookieStore.java
+++ b/splunk/src/main/java/com/splunk/SimpleCookieStore.java
@@ -28,6 +28,8 @@ import java.lang.StringBuilder;
  */
 class SimpleCookieStore {
 
+    public static final String SPLUNK_AUTH_COOKIE = "splunkd_";
+
     private Map<String, String> cookieJar = new HashMap<String, String>();
     /**
      * Adds cookies from a "Set-Cookie" header to the cookie store.
@@ -67,6 +69,19 @@ class SimpleCookieStore {
      */
     public Boolean isEmpty() {
         return cookieJar.isEmpty();
+    }
+
+    public boolean hasSplunkAuthCookie(){
+        if(cookieJar.isEmpty()){
+            return false;
+        }
+        for(String cookie : cookieJar.keySet()){
+            if(cookie.startsWith(SPLUNK_AUTH_COOKIE)){
+                System.out.println("HELLO");
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/splunk/src/test/java/com/splunk/CookieTest.java
+++ b/splunk/src/test/java/com/splunk/CookieTest.java
@@ -130,6 +130,7 @@ public class CookieTest extends SDKTestCase {
         service.cookieStore.add(otherCookies);
         service.login();
         service.getApplications();
+        service.cookieStore.removeAll();
     }
 
     @Ignore
@@ -154,7 +155,7 @@ public class CookieTest extends SDKTestCase {
         Map<String, Object> args = getStandardArgs();
 
         Service s  = new Service(args);
-
+        
         s.addCookie("bad=cookie");
         s.addCookie(validCookie);
         s.addCookie("another_bad=cookie");

--- a/splunk/src/test/java/com/splunk/CookieTest.java
+++ b/splunk/src/test/java/com/splunk/CookieTest.java
@@ -133,17 +133,17 @@ public class CookieTest extends SDKTestCase {
         service.cookieStore.removeAll();
     }
 
-    @Ignore
     @Test
     public void testUsingAuthTokenAndOtherCookie(){
-        String bearerToken = "eyJraWQiOiJzcGx1bmsuc2VjcmV0IiwiYWxnIjoiSFM1MTIiLCJ2ZXIiOiJ2MiIsInR0eXAiOiJzdGF0aWMifQ.eyJpc3MiOiJhZG1pbiBmcm9tIDZiMjIzZWI5NmY4YiIsInN1YiI6InRlc3QiLCJhdWQiOiJ1c2VyIiwiaWRwIjoiU3BsdW5rIiwianRpIjoiMWE1MWNiZWMyY2Q0ZGQyMWFjODcxOGRmMTA2MjRjZDU1YTlmM2M3Y2E3NjRkNTgwYWU0YTVmOWRiMDAzZjIxOSIsImlhdCI6MTY2MTE2Mzk0OSwiZXhwIjoxNjYzNzU1OTQ5LCJuYnIiOjE2NjM3NTU5NDl9.CfG8pCqNyupge_AM8oX1GXiEDYVkflJuJ4UkeqAWwH3UpKXP1efDhWX57ee_PkhwXCDwQtvmUWd3gCDFZASg_Q";
+        String validToken = service.getToken();
+        Assert.assertTrue(validToken.startsWith("Splunk "));
         String otherCookies = "load=balancer;";
         Map<String, Object> args = new HashMap<>();
         args.put("cookie", otherCookies);
-        args.put("host","localhost");
-        args.put("port", 8089);
-        Service s  = new Service(args);
-        s.setBearerToken(bearerToken);
+        args.put("host",service.getHost());
+        args.put("port", service.getPort());
+        Service s = new Service(args);
+        s.setToken(validToken);
         s.getApplications();
         Assert.assertEquals(otherCookies.trim(),s.cookieStore.getCookies().trim());
     }
@@ -155,7 +155,7 @@ public class CookieTest extends SDKTestCase {
         Map<String, Object> args = getStandardArgs();
 
         Service s  = new Service(args);
-        
+
         s.addCookie("bad=cookie");
         s.addCookie(validCookie);
         s.addCookie("another_bad=cookie");

--- a/splunk/src/test/java/com/splunk/CookieTest.java
+++ b/splunk/src/test/java/com/splunk/CookieTest.java
@@ -16,13 +16,11 @@
 
 package com.splunk;
 
+import java.net.HttpCookie;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 public class CookieTest extends SDKTestCase {
 
@@ -122,6 +120,31 @@ public class CookieTest extends SDKTestCase {
         s.addCookie("bad=cookie");
 
         s.getSettings().refresh();
+    }
+
+    @Test
+    public void testLoginWithOtherCookies() {
+        String otherCookies = "load=balancer;";
+        service.logout();
+        service.cookieStore.removeAll();
+        service.cookieStore.add(otherCookies);
+        service.login();
+        service.getApplications();
+    }
+
+    @Ignore
+    @Test
+    public void testUsingAuthTokenAndOtherCookie(){
+        String bearerToken = "eyJraWQiOiJzcGx1bmsuc2VjcmV0IiwiYWxnIjoiSFM1MTIiLCJ2ZXIiOiJ2MiIsInR0eXAiOiJzdGF0aWMifQ.eyJpc3MiOiJhZG1pbiBmcm9tIDZiMjIzZWI5NmY4YiIsInN1YiI6InRlc3QiLCJhdWQiOiJ1c2VyIiwiaWRwIjoiU3BsdW5rIiwianRpIjoiMWE1MWNiZWMyY2Q0ZGQyMWFjODcxOGRmMTA2MjRjZDU1YTlmM2M3Y2E3NjRkNTgwYWU0YTVmOWRiMDAzZjIxOSIsImlhdCI6MTY2MTE2Mzk0OSwiZXhwIjoxNjYzNzU1OTQ5LCJuYnIiOjE2NjM3NTU5NDl9.CfG8pCqNyupge_AM8oX1GXiEDYVkflJuJ4UkeqAWwH3UpKXP1efDhWX57ee_PkhwXCDwQtvmUWd3gCDFZASg_Q";
+        String otherCookies = "load=balancer;";
+        Map<String, Object> args = new HashMap<>();
+        args.put("cookie", otherCookies);
+        args.put("host","localhost");
+        args.put("port", 8089);
+        Service s  = new Service(args);
+        s.setBearerToken(bearerToken);
+        s.getApplications();
+        Assert.assertEquals(otherCookies.trim(),s.cookieStore.getCookies().trim());
     }
 
     @Test

--- a/splunk/src/test/java/com/splunk/IndexTest.java
+++ b/splunk/src/test/java/com/splunk/IndexTest.java
@@ -77,8 +77,8 @@ public class IndexTest extends SDKTestCase {
             // Cookies not implemented before version 6.2
             return;
         }
-        // Check that their are cookies at all
-        Assert.assertTrue(service.hasCookies());
+        // Check that their are Splunk Auth cookies at all
+        Assert.assertTrue(service.hasSplunkAuthCookies());
 
         // Make a service that only has that cookie
         String validCookie = service.stringifyCookies();

--- a/splunk/src/test/java/com/splunk/ReceiverTest.java
+++ b/splunk/src/test/java/com/splunk/ReceiverTest.java
@@ -36,7 +36,7 @@ public class ReceiverTest extends SDKTestCase {
     @Test
     public void testReceiverWithCookie() {
         Assume.assumeTrue(service.versionIsAtLeast("6.2"));
-        Assert.assertTrue(service.hasCookies());
+        Assert.assertTrue(service.hasSplunkAuthCookies());
         testReceiver(service);
     }
     // Make a few simple requests and make sure the results look ok.

--- a/splunk/src/test/java/com/splunk/ReceiverTest.java
+++ b/splunk/src/test/java/com/splunk/ReceiverTest.java
@@ -24,6 +24,8 @@ import org.junit.Assume;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ReceiverTest extends SDKTestCase {
 
@@ -39,6 +41,25 @@ public class ReceiverTest extends SDKTestCase {
         Assert.assertTrue(service.hasSplunkAuthCookies());
         testReceiver(service);
     }
+
+    @Test
+    public void testReceiverWithoutSplunkCookie() {
+        String validToken = service.getToken();
+        Assert.assertTrue(validToken.startsWith("Splunk "));
+        String otherCookies = "load=balancer;";
+        Map<String, Object> args = new HashMap<>();
+        args.put("cookie", otherCookies);
+        args.put("host",service.getHost());
+        args.put("port", service.getPort());
+        Service s = new Service(args);
+        s.setToken(validToken);
+        s.version = s.getInfo().getVersion();
+        System.out.println(s.version);
+        Assume.assumeTrue(s.versionIsAtLeast("6.2"));
+        Assert.assertTrue(!s.cookieStore.isEmpty());
+        testReceiver(s);
+    }
+
     // Make a few simple requests and make sure the results look ok.
     public void testReceiver(Service passedService) {
         Receiver receiver = passedService.getReceiver();


### PR DESCRIPTION
Replace empty cookie check with check for Splunk Authorisation cookie. Added code to add existing cookies such as from load balancer along with authorisation cookie for Splunk