### PR TITLE
Re-fetch instanceType if not provided

### DIFF
--- a/splunk/src/main/java/com/splunk/HttpService.java
+++ b/splunk/src/main/java/com/splunk/HttpService.java
@@ -51,10 +51,11 @@ public class HttpService {
     private static String HTTPS_SCHEME = "https";
     private static String HTTP_SCHEME = "http";
     private static String HOSTNAME = "localhost";
+    private static String HOSTIP = "127.0.0.1";
 
     private static final HostnameVerifier HOSTNAME_VERIFIER = new HostnameVerifier() {
         public boolean verify(String s, SSLSession sslSession) {
-            if (s.equals(HOSTNAME)) {
+            if (s.equals(HOSTNAME) || s.equals(HOSTIP)) {
                 return true;
             } else {
                 HostnameVerifier hv = HttpsURLConnection.getDefaultHostnameVerifier();

--- a/splunk/src/main/java/com/splunk/Service.java
+++ b/splunk/src/main/java/com/splunk/Service.java
@@ -1356,6 +1356,9 @@ public class Service extends BaseService {
 
 
     public boolean enableV2SearchApi(){
+        if(null == this.instanceType){
+            this.instanceType = this.getInfo().getInstanceType();
+        }
         if(this.instanceType.equalsIgnoreCase("cloud")) {
             return versionIsAtLeast("9.0.2209");
         }else{
@@ -1411,6 +1414,9 @@ public class Service extends BaseService {
      *         or 1 if this version is greater than the given version.
      */
     public int versionCompare(String otherVersion) {
+        if(null == this.version){
+            this.version = this.getInfo().getVersion();
+        }
         String[] components1 = this.version.split("\\.");
         String[] components2 = otherVersion.split("\\.");
         int numComponents = Math.max(components1.length, components2.length);

--- a/splunk/src/test/java/com/splunk/ServiceTest.java
+++ b/splunk/src/test/java/com/splunk/ServiceTest.java
@@ -735,4 +735,19 @@ public class ServiceTest extends SDKTestCase {
         }
     }
 
+    /*
+    Test when Service instance is created using token, it doesn't result in Null Pointer while accessing instanceType and version
+     */
+    @Test
+    public void testServiceWithTokenAuth(){
+        Service newService = new Service(service.getHost());
+        newService.setToken(service.getToken());
+        try{
+            newService.enableV2SearchApi();
+            newService.versionCompare("9.0.2");
+        }catch (Exception ex){
+            Assert.assertNull(ex);
+        }
+    }
+
 }


### PR DESCRIPTION
- re-fetch instancetype and version if not set within Service instance to avoid NPE
- also provide local IP as alternative to localhost, addressing issue with certain local workflows